### PR TITLE
feat: First draft for generic spend structure

### DIFF
--- a/vesting_contracts/lib/vesting_contracts/datums.ak
+++ b/vesting_contracts/lib/vesting_contracts/datums.ak
@@ -1,10 +1,15 @@
-use aiken/hash.{Blake2b_224, Blake2b_256, Hash}
-use aiken/transaction/credential.{Script}
+use aiken/hash.{Blake2b_256, Hash}
+use aiken/transaction.{Datum, InlineDatum}
 use sundae/multisig.{MultisigScript}
 use vesting_contracts/redeemers.{ClaimEntry}
 
 pub type TreasuryDatum {
   owner: MultisigScript,
   claimant_tree: Hash<Blake2b_256, ClaimEntry>,
-  vesting_program: Hash<Blake2b_224, Script>,
+}
+
+pub fn extract_treasury_datum(on_chain_datum: Datum) -> TreasuryDatum {
+  expect InlineDatum(inline_datum) = on_chain_datum
+  expect casted_datum: TreasuryDatum = inline_datum
+  casted_datum
 }

--- a/vesting_contracts/lib/vesting_contracts/datums.ak
+++ b/vesting_contracts/lib/vesting_contracts/datums.ak
@@ -3,11 +3,20 @@ use aiken/transaction.{Datum, InlineDatum}
 use sundae/multisig.{MultisigScript}
 use vesting_contracts/redeemers.{ClaimEntry}
 
+//Prefix of the reference nft asset id according to CIP-68
+pub const reference_prefix = #"000643b0"
+
+//Prefix of the nft asset id according to CIP-68
+pub const user_nft_prefix = #"000de140"
+
 pub type TreasuryDatum {
+  //Owner of the treasury which can perform the reclaim tx
   owner: MultisigScript,
+  //Root of the merkle tree holding the claims
   claimant_tree: Hash<Blake2b_256, ClaimEntry>,
 }
 
+//Cast a datum to a TreasuryDatum
 pub fn extract_treasury_datum(on_chain_datum: Datum) -> TreasuryDatum {
   expect InlineDatum(inline_datum) = on_chain_datum
   expect casted_datum: TreasuryDatum = inline_datum

--- a/vesting_contracts/lib/vesting_contracts/linear_vesting/mint.ak
+++ b/vesting_contracts/lib/vesting_contracts/linear_vesting/mint.ak
@@ -1,17 +1,19 @@
 use aiken/transaction.{ScriptContext}
+use vesting_contracts/merkle_tree_blake2b.{Proof}
+use vesting_contracts/redeemers.{ClaimEntry}
 
 pub type LinearVestingMintRedeemer {
   Vest
   Split
   Combine
-  Claim
+  Claim { claim_proof: Proof<ClaimEntry>, claim_entry: ClaimEntry }
 }
 
-pub fn mint(redeemer: LinearVestingMintRedeemer, ctx: ScriptContext) -> Bool {
+pub fn mint(redeemer: LinearVestingMintRedeemer, _ctx: ScriptContext) -> Bool {
   when redeemer is {
     Vest -> True
     Split -> True
     Combine -> True
-    Claim -> True
+    Claim(_, _) -> True
   }
 }

--- a/vesting_contracts/lib/vesting_contracts/linear_vesting/mint.ak
+++ b/vesting_contracts/lib/vesting_contracts/linear_vesting/mint.ak
@@ -1,19 +1,127 @@
-use aiken/transaction.{ScriptContext}
+use aiken/bytearray.{concat, drop, take}
+use aiken/cbor.{serialise}
+use aiken/dict.{Dict, from_list, get, size, to_list}
+use aiken/hash.{Blake2b_224, Hash, blake2b_256}
+use aiken/list.{all, filter, indexed_map, length}
+use aiken/math.{abs}
+use aiken/transaction.{
+  Output, OutputReference, ScriptContext, find_script_outputs,
+}
+use aiken/transaction/credential.{Script}
+use aiken/transaction/value.{
+  AssetName, PolicyId, from_minted_value, to_dict, tokens,
+}
+use vesting_contracts/datums.{reference_prefix, user_nft_prefix}
 use vesting_contracts/merkle_tree_blake2b.{Proof}
 use vesting_contracts/redeemers.{ClaimEntry}
+use vesting_contracts/util.{find_script_inputs}
 
 pub type LinearVestingMintRedeemer {
   Vest
-  Split
-  Combine
   Claim { claim_proof: Proof<ClaimEntry>, claim_entry: ClaimEntry }
 }
 
-pub fn mint(redeemer: LinearVestingMintRedeemer, _ctx: ScriptContext) -> Bool {
+//This structure is used to build unique asset names for multiple outputs
+type VestingNFTSignature {
+  output_reference: OutputReference,
+  index: Int,
+}
+
+pub fn mint(
+  policy_id: PolicyId,
+  treasury_hash: Hash<Blake2b_224, Script>,
+  redeemer: LinearVestingMintRedeemer,
+  ctx: ScriptContext,
+) -> Bool {
   when redeemer is {
     Vest -> True
-    Split -> True
-    Combine -> True
-    Claim(_, _) -> True
+    Claim(_, _) -> claim(treasury_hash, policy_id, ctx)
   }
+}
+
+fn claim(
+  treasury_hash: Hash<Blake2b_224, Script>,
+  policy_id: PolicyId,
+  ctx: ScriptContext,
+) -> Bool {
+  expect [treasury_input] =
+    find_script_inputs(ctx.transaction.inputs, treasury_hash)
+  expect Some(minted_burned_assets) =
+    from_minted_value(ctx.transaction.mint) |> to_dict |> get(policy_id)
+  let (burned_assets, minted_assets) = split_mints_burns(minted_burned_assets)
+  let vesting_outputs = find_script_outputs(ctx.transaction.outputs, policy_id)
+  let signature_template =
+    VestingNFTSignature {
+      output_reference: treasury_input.output_reference,
+      index: 0,
+    }
+  //Due to the use of cip-68 we expect double the amount of vesting outputs as minted assets
+  let expected_minted_assets = length(vesting_outputs) * 2
+  and {
+    (size(burned_assets) == 0)?,
+    (size(minted_assets) == expected_minted_assets)?,
+    verify_cip68_pairs(minted_assets)?,
+    verify_split_vesting(vesting_outputs, signature_template, policy_id)?,
+  }
+}
+
+fn split_mints_burns(
+  minted_burned_assets: Dict<AssetName, Int>,
+) -> (Dict<AssetName, Int>, Dict<AssetName, Int>) {
+  let asset_list = minted_burned_assets |> to_list()
+  (
+    from_list(asset_list |> filter(fn(a) { a.2nd < 0 }), bytearray.compare),
+    from_list(asset_list |> filter(fn(a) { a.2nd > 0 }), bytearray.compare),
+  )
+}
+
+fn verify_cip68_pairs(minted_assets: Dict<AssetName, Int>) -> Bool {
+  let reference_nfts =
+    minted_assets
+      |> to_list()
+      |> filter(fn(a) { take(a.1st, 4) == reference_prefix })
+  let reference_match =
+    reference_nfts
+      |> all(
+          fn(a) {
+            expect Some(user_nft_amount) =
+              minted_assets |> get(concat(user_nft_prefix, drop(a.1st, 4)))
+            let absolute_amount = abs(a.2nd)
+            expect absolute_amount == 1
+            a.2nd == user_nft_amount
+          },
+        )
+  let expected_nft_count = length(reference_nfts) * 2
+  and {
+    reference_match?,
+    (expected_nft_count == size(minted_assets))?,
+  }
+}
+
+fn verify_split_vesting(
+  vesting_outputs: List<Output>,
+  signature_template: VestingNFTSignature,
+  policy_id: PolicyId,
+) -> Bool {
+  vesting_outputs
+    |> indexed_map(
+        fn(i, vo) {
+          let signature = VestingNFTSignature { ..signature_template, index: i }
+          verify_vesting_output(vo, signature, policy_id)
+        },
+      )
+    |> all(identity)
+}
+
+fn verify_vesting_output(
+  vo: Output,
+  signature: VestingNFTSignature,
+  policy_id: PolicyId,
+) -> Bool {
+  let serialised_signature = blake2b_256(serialise(signature))
+  let correct_asset_name =
+    reference_prefix |> concat(take(serialised_signature, 28))
+  let tokens = vo.value |> tokens(policy_id)
+  expect Some(1) = get(tokens, correct_asset_name)
+  size(tokens) == 1
 }

--- a/vesting_contracts/lib/vesting_contracts/linear_vesting/spend.ak
+++ b/vesting_contracts/lib/vesting_contracts/linear_vesting/spend.ak
@@ -1,5 +1,5 @@
 use aiken/time.{PosixTime}
-use aiken/transaction.{OutputReference, ScriptContext}
+use aiken/transaction.{Datum, InlineDatum, OutputReference, ScriptContext}
 
 pub type LinearVestingSpendRedeemer {
   Vest
@@ -16,6 +16,12 @@ pub type LinearVestingParameters {
 pub type LinearVestingDatum {
   vesting_nft: ByteArray,
   vesting_parameters: LinearVestingParameters,
+}
+
+pub fn extract_linear_vesting_datum(datum: Datum) -> LinearVestingDatum {
+  expect InlineDatum(inline) = datum
+  expect linear_vesting_datum: LinearVestingDatum = inline
+  linear_vesting_datum
 }
 
 pub fn spend(

--- a/vesting_contracts/lib/vesting_contracts/linear_vesting/spend.ak
+++ b/vesting_contracts/lib/vesting_contracts/linear_vesting/spend.ak
@@ -14,6 +14,7 @@ pub type LinearVestingParameters {
 }
 
 pub type LinearVestingDatum {
+  vesting_nft: ByteArray,
   vesting_parameters: LinearVestingParameters,
 }
 
@@ -31,9 +32,9 @@ pub fn spend(
 }
 
 fn vest(
-  output_reference: OutputReference,
-  datum: LinearVestingDatum,
-  ctx: ScriptContext,
+  _output_reference: OutputReference,
+  _datum: LinearVestingDatum,
+  _ctx: ScriptContext,
 ) -> Bool {
   True
 }

--- a/vesting_contracts/lib/vesting_contracts/linear_vesting/spend.ak
+++ b/vesting_contracts/lib/vesting_contracts/linear_vesting/spend.ak
@@ -1,46 +1,56 @@
 use aiken/time.{PosixTime}
-use aiken/transaction.{Datum, InlineDatum, OutputReference, ScriptContext}
+use aiken/transaction.{
+  Datum, InlineDatum, OutputReference, ScriptContext, find_input,
+}
+use aiken/transaction/credential.{Address, ScriptCredential}
+use vesting_contracts/treasury.{verify_vesting_program}
 
 pub type LinearVestingSpendRedeemer {
   Vest
-  Split
-  Combine
 }
 
 pub type LinearVestingParameters {
+  //The time that value in the vesting utxo starts vesting
   start_time: PosixTime,
+  //At which interval the value vests
   vest_frequency: PosixTime,
+  //Number of vesting periods left (So after vest_periods*vest_frequency+start_time all assets are vested)
   vest_periods: Int,
+  //Cliff time, tokens are not vested before this time
+  cliff_time: PosixTime,
 }
 
 pub type LinearVestingDatum {
-  vesting_nft: ByteArray,
   vesting_parameters: LinearVestingParameters,
 }
 
-pub fn extract_linear_vesting_datum(datum: Datum) -> LinearVestingDatum {
+pub type CIP68Datum {
+  //Metadata fields holding name, img etc for the stake nft following CIP-25
+  metadata: List<(ByteArray, ByteArray)>,
+  //Following on chain metadata standard in CIP-68
+  version: Int,
+  //Data defining the time the assets are to be locked and how to unlock
+  extra: LinearVestingDatum,
+}
+
+pub fn extract_linear_vesting_datum(datum: Datum) -> CIP68Datum {
   expect InlineDatum(inline) = datum
-  expect linear_vesting_datum: LinearVestingDatum = inline
+  expect linear_vesting_datum: CIP68Datum = inline
   linear_vesting_datum
 }
 
 pub fn spend(
   output_reference: OutputReference,
-  datum: LinearVestingDatum,
-  redeemer: LinearVestingSpendRedeemer,
+  _redeemer: LinearVestingSpendRedeemer,
   ctx: ScriptContext,
 ) -> Bool {
-  when redeemer is {
-    Vest -> vest(output_reference, datum, ctx)
-    Split -> False
-    Combine -> False
-  }
+  vest(output_reference, ctx)
 }
 
-fn vest(
-  _output_reference: OutputReference,
-  _datum: LinearVestingDatum,
-  _ctx: ScriptContext,
-) -> Bool {
-  True
+//The logic is based on multiple inputs and multiple outputs. To avoid recalculating a lot
+//we calculate it once in a withdrawal script and only check the presence of the script here.
+fn vest(output_reference: OutputReference, ctx: ScriptContext) -> Bool {
+  expect Some(input) = find_input(ctx.transaction.inputs, output_reference)
+  expect Address(ScriptCredential(vesting_hash), _) = input.output.address
+  verify_vesting_program(vesting_hash, ctx.transaction)
 }

--- a/vesting_contracts/lib/vesting_contracts/linear_vesting/withdrawal.ak
+++ b/vesting_contracts/lib/vesting_contracts/linear_vesting/withdrawal.ak
@@ -1,9 +1,106 @@
-use aiken/transaction.{ScriptContext}
+use aiken/hash.{Blake2b_224, Hash}
+use aiken/list.{filter_map, foldl}
+use aiken/transaction.{Output, ScriptContext, find_script_outputs}
+use aiken/transaction/credential.{
+  Inline, Script, ScriptCredential, StakeCredential,
+}
+use aiken/transaction/value.{Value, flatten_with, from_asset, merge, zero}
+use vesting_contracts/datums.{extract_treasury_datum}
 use vesting_contracts/linear_vesting/mint.{Claim, LinearVestingMintRedeemer}
+use vesting_contracts/merkle_tree_blake2b.{Proof, from_hash}
+use vesting_contracts/redeemers.{ClaimEntry}
+use vesting_contracts/treasury.{verify_claim}
 
-pub fn withdraw(redeemer: LinearVestingMintRedeemer, ctx: ScriptContext) -> Bool {
+pub fn withdraw(
+  linear_vesting_stake_credential: StakeCredential,
+  treasury_hash: Hash<Blake2b_224, Script>,
+  redeemer: LinearVestingMintRedeemer,
+  ctx: ScriptContext,
+) -> Bool {
   when redeemer is {
-    Claim -> True
+    Claim(claim_proof, claim_entry) ->
+      claim(
+        linear_vesting_stake_credential,
+        treasury_hash,
+        claim_proof,
+        claim_entry,
+        ctx,
+      )
     _ -> False
   }
+}
+
+fn claim(
+  linear_vesting_stake_credential: StakeCredential,
+  treasury_hash: Hash<Blake2b_224, Script>,
+  claim_proof: Proof<ClaimEntry>,
+  claim_entry: ClaimEntry,
+  ctx: ScriptContext,
+) -> Bool {
+  expect [treasury_input] =
+    ctx.transaction.inputs
+      |> filter_map(
+          fn(input) {
+            if
+            input.output.address.payment_credential == ScriptCredential(
+              treasury_hash,
+            ){
+            
+              Some(input.output)
+            } else {
+              None
+            }
+          },
+        )
+  expect [treasury_output] =
+    find_script_outputs(ctx.transaction.outputs, treasury_hash)
+  let treasury_input_datum = extract_treasury_datum(treasury_input.datum)
+  let treasury_output_datum = extract_treasury_datum(treasury_output.datum)
+
+  expect Inline(ScriptCredential(linear_vesting_hash)) =
+    linear_vesting_stake_credential
+  let linear_vesting_outputs =
+    find_script_outputs(ctx.transaction.outputs, linear_vesting_hash)
+  and {
+    verify_claim(
+      claim_proof,
+      claim_entry,
+      from_hash(treasury_input_datum.claimant_tree),
+      from_hash(treasury_output_datum.claimant_tree),
+    )?,
+    verify_vesting_value(
+      claim_entry.vesting_value,
+      linear_vesting_outputs,
+      linear_vesting_hash,
+    )?,
+  }
+}
+
+fn verify_vesting_value(
+  vesting_value: Value,
+  lv_outputs: List<Output>,
+  vesting_mint_policy: Hash<Blake2b_224, Script>,
+) -> Bool {
+  let actual_vesting_value =
+    lv_outputs
+      |> foldl(
+          zero(),
+          fn(lv_output, total) {
+            merge(
+              total,
+              lv_output.value
+                |> flatten_with(
+                    fn(policy_id, asset_name, amount) {
+                      if policy_id != vesting_mint_policy {
+                        Some(from_asset(policy_id, asset_name, amount))
+                      } else {
+                        None
+                      }
+                    },
+                  )
+                |> foldl(zero(), fn(v, t) { merge(v, t) }),
+            )
+          },
+        )
+  actual_vesting_value == vesting_value
 }

--- a/vesting_contracts/lib/vesting_contracts/linear_vesting/withdrawal.ak
+++ b/vesting_contracts/lib/vesting_contracts/linear_vesting/withdrawal.ak
@@ -1,19 +1,28 @@
+use aiken/builtin.{b_data}
 use aiken/cbor.{serialise}
 use aiken/hash.{Blake2b_224, Hash}
-use aiken/list.{all, foldl, map}
-use aiken/transaction.{Output, ScriptContext, find_script_outputs}
+use aiken/interval.{Finite}
+use aiken/list.{all, at, foldl, map, push}
+use aiken/math.{min}
+use aiken/time.{PosixTime}
+use aiken/transaction.{InlineDatum, Output, ScriptContext, find_script_outputs}
 use aiken/transaction/credential.{
   Inline, Script, ScriptCredential, StakeCredential,
 }
 use aiken/transaction/value.{
-  Value, flatten_with, from_asset, from_lovelace, merge, negate, zero,
+  Value, flatten_with, from_asset, merge, negate, zero,
 }
 use vesting_contracts/datums.{extract_treasury_datum}
-use vesting_contracts/linear_vesting/mint.{Claim, LinearVestingMintRedeemer}
-use vesting_contracts/linear_vesting/spend.{extract_linear_vesting_datum}
+use vesting_contracts/linear_vesting/mint.{
+  Claim, LinearVestingMintRedeemer, Vest,
+}
+use vesting_contracts/linear_vesting/spend.{
+  LinearVestingDatum, LinearVestingParameters, extract_linear_vesting_datum,
+}
 use vesting_contracts/merkle_tree_blake2b.{Proof, from_hash}
 use vesting_contracts/redeemers.{ClaimEntry}
 use vesting_contracts/treasury.{verify_claim}
+use vesting_contracts/util.{find_script_inputs, min_utxo}
 
 pub fn withdraw(
   linear_vesting_stake_credential: StakeCredential,
@@ -21,21 +30,136 @@ pub fn withdraw(
   redeemer: LinearVestingMintRedeemer,
   ctx: ScriptContext,
 ) -> Bool {
+  expect Inline(ScriptCredential(linear_vesting_hash)) =
+    linear_vesting_stake_credential
   when redeemer is {
     Claim(claim_proof, claim_entry) ->
-      claim(
-        linear_vesting_stake_credential,
-        treasury_hash,
-        claim_proof,
-        claim_entry,
-        ctx,
+      claim(linear_vesting_hash, treasury_hash, claim_proof, claim_entry, ctx)
+    Vest -> vest(ctx, linear_vesting_hash)
+  }
+}
+
+fn vest(ctx: ScriptContext, linear_vesting_hash: ByteArray) -> Bool {
+  let linear_vesting_outputs =
+    find_script_outputs(ctx.transaction.outputs, linear_vesting_hash)
+  let linear_vesting_inputs =
+    find_script_inputs(ctx.transaction.inputs, linear_vesting_hash)
+      |> map(fn(i) { i.output })
+  expect Finite(time) = ctx.transaction.validity_range.lower_bound.bound_type
+  verify_vesting_inputs_outputs(
+    linear_vesting_inputs,
+    linear_vesting_outputs,
+    linear_vesting_hash,
+    time,
+  )
+}
+
+//Verifies that vested value - redeemable value = vested value in output for all vesting
+//inputs and outputs combined.
+fn verify_vesting_inputs_outputs(
+  vesting_inputs: List<Output>,
+  vesting_outputs: List<Output>,
+  linear_vesting_hash: ByteArray,
+  time: PosixTime,
+) -> Bool {
+  //We use this input as an example to build our expected parameters
+  expect Some(example_input) = vesting_inputs |> at(0)
+  //Inputs should be on the same program, but might be on different stages of redeeming
+  //so we use the parameters AFTER redeeming to ensure they all follow the same schedule
+  let expected_vesting_parameters =
+    vesting_parameters_after_redeem(
+      time,
+      extract_linear_vesting_datum(example_input.datum).extra.vesting_parameters,
+    )
+  //Sum up vested value in inputs
+  let current_vested_value =
+    vesting_inputs |> foldl(zero(), fn(v, t) { merge(vested_value(v), t) })
+  //Sum up redeemable value in inputs
+  let redeemable_value =
+    vesting_inputs
+      |> foldl(
+          zero(),
+          fn(v, t) {
+            merge(redeemable_value(time, v, expected_vesting_parameters), t)
+          },
+        )
+  //Expected vested value in outputs = vested value - redeemable value
+  let expected_vested_value =
+    current_vested_value |> merge(negate(redeemable_value))
+  and {
+    verify_vesting_parameters(
+      serialise(expected_vesting_parameters),
+      vesting_outputs,
+    )?,
+    verify_vesting_value(
+      expected_vested_value,
+      vesting_outputs,
+      linear_vesting_hash,
+    )?,
+  }
+}
+
+//Calculates vested value
+//TODO: filter out reference nft
+fn vested_value(vesting_output: Output) -> Value {
+  vesting_output.value |> merge(negate(min_utxo()))
+}
+
+//Calculates redeemable value for this output based on time
+//NOTE: Fails if vesting parameters do not match to expected after redeem
+fn redeemable_value(
+  time: PosixTime,
+  vesting_output: Output,
+  expected_vesting_parameters: LinearVestingParameters,
+) -> Value {
+  let vesting_datum = extract_linear_vesting_datum(vesting_output.datum)
+  let vp_after_redeem =
+    vesting_parameters_after_redeem(
+      time,
+      vesting_datum.extra.vesting_parameters,
+    )
+  expect vp_after_redeem == expected_vesting_parameters
+  let vested_value = vested_value(vesting_output)
+  let redeemable_periods =
+    vesting_datum.extra.vesting_parameters.vest_periods - vp_after_redeem.vest_periods
+  vested_value
+    |> flatten_with(
+        fn(policy_id, asset_name, amount) {
+          let redeemable_amount =
+            amount * redeemable_periods / vesting_datum.extra.vesting_parameters.vest_periods
+          if redeemable_amount > 0 {
+            Some(from_asset(policy_id, asset_name, redeemable_amount))
+          } else {
+            None
+          }
+        },
       )
-    _ -> False
+    |> foldl(zero(), fn(v, t) { merge(v, t) })
+}
+
+//Transform vesting parameters to how they should be after redeem at this time
+fn vesting_parameters_after_redeem(
+  time: PosixTime,
+  vesting_parameters: LinearVestingParameters,
+) -> LinearVestingParameters {
+  if time > vesting_parameters.cliff_time {
+    let redeemable_periods =
+      min(
+        vesting_parameters.vest_periods,
+        ( time - vesting_parameters.start_time ) / vesting_parameters.vest_frequency,
+      )
+    LinearVestingParameters {
+      ..vesting_parameters,
+      vest_periods: vesting_parameters.vest_periods - redeemable_periods,
+      start_time: vesting_parameters.start_time + redeemable_periods * vesting_parameters.vest_frequency,
+    }
+  } else {
+    vesting_parameters
   }
 }
 
 fn claim(
-  linear_vesting_stake_credential: StakeCredential,
+  linear_vesting_hash: ByteArray,
   treasury_hash: Hash<Blake2b_224, Script>,
   claim_proof: Proof<ClaimEntry>,
   claim_entry: ClaimEntry,
@@ -51,10 +175,24 @@ fn claim(
   let treasury_input_datum = extract_treasury_datum(treasury_input.datum)
   let treasury_output_datum = extract_treasury_datum(treasury_output.datum)
 
-  expect Inline(ScriptCredential(linear_vesting_hash)) =
-    linear_vesting_stake_credential
   let linear_vesting_outputs =
     find_script_outputs(ctx.transaction.outputs, linear_vesting_hash)
+  expect Some(example_output) = linear_vesting_outputs |> at(0)
+  expect claim_vesting_parameters: LinearVestingParameters =
+    b_data(claim_entry.vesting_parameters)
+  let linear_vesting_inputs =
+    push(
+      find_script_inputs(ctx.transaction.inputs, linear_vesting_hash)
+        |> map(fn(o) { o.output }),
+      Output {
+        ..example_output,
+        value: min_utxo() |> merge(claim_entry.vesting_value),
+        datum: InlineDatum(
+          LinearVestingDatum { vesting_parameters: claim_vesting_parameters },
+        ),
+      },
+    )
+  expect Finite(time) = ctx.transaction.validity_range.lower_bound.bound_type
   and {
     verify_claim(
       claim_proof,
@@ -62,31 +200,31 @@ fn claim(
       from_hash(treasury_input_datum.claimant_tree),
       from_hash(treasury_output_datum.claimant_tree),
     )?,
-    verify_vesting_parameters(
-      claim_entry.vesting_parameters,
-      linear_vesting_outputs,
-    )?,
-    verify_vesting_value(
-      claim_entry.vesting_value,
+    verify_vesting_inputs_outputs(
+      linear_vesting_inputs,
       linear_vesting_outputs,
       linear_vesting_hash,
-    )?,
+      time,
+    ),
   }
 }
 
+//Verify that all outputs have the expected parameters
 fn verify_vesting_parameters(
   vesting_parameters: ByteArray,
-  linear_vesting_outputs,
+  linear_vesting_outputs: List<Output>,
 ) -> Bool {
   linear_vesting_outputs
     |> all(
         fn(o) {
           let linear_vesting_datum = extract_linear_vesting_datum(o.datum)
-          serialise(linear_vesting_datum.vesting_parameters) == vesting_parameters
+          serialise(linear_vesting_datum.extra.vesting_parameters) == vesting_parameters
         },
       )
 }
 
+//Verify that vested value in outputs matches expected vesting value
+//TODO: refactor to use vested_value function
 fn verify_vesting_value(
   vesting_value: Value,
   lv_outputs: List<Output>,
@@ -109,10 +247,7 @@ fn verify_vesting_value(
                       }
                     },
                   )
-                |> foldl(
-                    negate(from_lovelace(2_000_000)),
-                    fn(v, t) { merge(v, t) },
-                  ),
+                |> foldl(negate(min_utxo()), fn(v, t) { merge(v, t) }),
             )
           },
         )

--- a/vesting_contracts/lib/vesting_contracts/linear_vesting/withdrawal.ak
+++ b/vesting_contracts/lib/vesting_contracts/linear_vesting/withdrawal.ak
@@ -1,12 +1,16 @@
+use aiken/cbor.{serialise}
 use aiken/hash.{Blake2b_224, Hash}
-use aiken/list.{filter_map, foldl}
+use aiken/list.{all, foldl, map}
 use aiken/transaction.{Output, ScriptContext, find_script_outputs}
 use aiken/transaction/credential.{
   Inline, Script, ScriptCredential, StakeCredential,
 }
-use aiken/transaction/value.{Value, flatten_with, from_asset, merge, zero}
+use aiken/transaction/value.{
+  Value, flatten_with, from_asset, from_lovelace, merge, negate, zero,
+}
 use vesting_contracts/datums.{extract_treasury_datum}
 use vesting_contracts/linear_vesting/mint.{Claim, LinearVestingMintRedeemer}
+use vesting_contracts/linear_vesting/spend.{extract_linear_vesting_datum}
 use vesting_contracts/merkle_tree_blake2b.{Proof, from_hash}
 use vesting_contracts/redeemers.{ClaimEntry}
 use vesting_contracts/treasury.{verify_claim}
@@ -38,20 +42,10 @@ fn claim(
   ctx: ScriptContext,
 ) -> Bool {
   expect [treasury_input] =
-    ctx.transaction.inputs
-      |> filter_map(
-          fn(input) {
-            if
-            input.output.address.payment_credential == ScriptCredential(
-              treasury_hash,
-            ){
-            
-              Some(input.output)
-            } else {
-              None
-            }
-          },
-        )
+    find_script_outputs(
+      map(ctx.transaction.inputs, fn(i) { i.output }),
+      treasury_hash,
+    )
   expect [treasury_output] =
     find_script_outputs(ctx.transaction.outputs, treasury_hash)
   let treasury_input_datum = extract_treasury_datum(treasury_input.datum)
@@ -68,12 +62,29 @@ fn claim(
       from_hash(treasury_input_datum.claimant_tree),
       from_hash(treasury_output_datum.claimant_tree),
     )?,
+    verify_vesting_parameters(
+      claim_entry.vesting_parameters,
+      linear_vesting_outputs,
+    )?,
     verify_vesting_value(
       claim_entry.vesting_value,
       linear_vesting_outputs,
       linear_vesting_hash,
     )?,
   }
+}
+
+fn verify_vesting_parameters(
+  vesting_parameters: ByteArray,
+  linear_vesting_outputs,
+) -> Bool {
+  linear_vesting_outputs
+    |> all(
+        fn(o) {
+          let linear_vesting_datum = extract_linear_vesting_datum(o.datum)
+          serialise(linear_vesting_datum.vesting_parameters) == vesting_parameters
+        },
+      )
 }
 
 fn verify_vesting_value(
@@ -98,7 +109,10 @@ fn verify_vesting_value(
                       }
                     },
                   )
-                |> foldl(zero(), fn(v, t) { merge(v, t) }),
+                |> foldl(
+                    negate(from_lovelace(2_000_000)),
+                    fn(v, t) { merge(v, t) },
+                  ),
             )
           },
         )

--- a/vesting_contracts/lib/vesting_contracts/redeemers.ak
+++ b/vesting_contracts/lib/vesting_contracts/redeemers.ak
@@ -1,4 +1,6 @@
 use aiken/cbor.{serialise}
+use aiken/hash.{Blake2b_224, Hash}
+use aiken/transaction/credential.{Script}
 use aiken/transaction/value.{Value}
 use sundae/multisig.{MultisigScript}
 use vesting_contracts/merkle_tree_blake2b.{Proof}
@@ -8,6 +10,7 @@ pub type ClaimEntry {
   vesting_value: Value,
   direct_value: Value,
   vesting_parameters: ByteArray,
+  vesting_program: Hash<Blake2b_224, Script>,
 }
 
 pub fn serialise_entry(claim_entry: ClaimEntry) -> ByteArray {

--- a/vesting_contracts/lib/vesting_contracts/redeemers.ak
+++ b/vesting_contracts/lib/vesting_contracts/redeemers.ak
@@ -6,22 +6,25 @@ use sundae/multisig.{MultisigScript}
 use vesting_contracts/merkle_tree_blake2b.{Proof}
 
 pub type ClaimEntry {
+  //Claimant which can perform the claim tx for this entry
   claimant: MultisigScript,
+  //The value to be deposited into the vesting program
   vesting_value: Value,
+  //Value the claimant can claim directly into their wallet
   direct_value: Value,
+  //Serialised parameters for the vesting program
+  //Serialised to support different structures for future vesting program types
   vesting_parameters: ByteArray,
+  //The hash of the vesting program validator
   vesting_program: Hash<Blake2b_224, Script>,
 }
 
+//Wrapper needed to feed to merkle tree functions for serialising ClaimEntry
 pub fn serialise_entry(claim_entry: ClaimEntry) -> ByteArray {
   serialise(claim_entry)
 }
 
-pub type TxType {
+pub type TreasuryRedeemer {
   Claim { claim_proof: Proof<ClaimEntry>, claim_entry: ClaimEntry }
   Reclaim
-}
-
-pub type TreasuryRedeemer {
-  tx_type: TxType,
 }

--- a/vesting_contracts/lib/vesting_contracts/treasury.ak
+++ b/vesting_contracts/lib/vesting_contracts/treasury.ak
@@ -1,0 +1,93 @@
+use aiken/dict.{has_key}
+use aiken/transaction.{
+  Input, Output, OutputReference, Transaction, find_input, find_script_outputs,
+}
+use aiken/transaction/credential.{Address, Inline, ScriptCredential}
+use aiken/transaction/value.{Value, merge, negate, zero}
+use sundae/multisig.{satisfied}
+use vesting_contracts/datums.{TreasuryDatum, extract_treasury_datum}
+use vesting_contracts/merkle_tree_blake2b.{Proof, Root, from_hash, is_member}
+use vesting_contracts/redeemers.{ClaimEntry, serialise_entry}
+
+pub fn verify_vesting_program(claim_entry: ClaimEntry, tx: Transaction) -> Bool {
+  tx.withdrawals
+    |> has_key(Inline(ScriptCredential(claim_entry.vesting_program)))
+}
+
+pub fn verify_datum(
+  input_datum: TreasuryDatum,
+  output_datum: TreasuryDatum,
+) -> Bool {
+  output_datum == TreasuryDatum {
+    ..input_datum,
+    claimant_tree: output_datum.claimant_tree,
+  }
+}
+
+pub fn verify_value(
+  claim_entry: ClaimEntry,
+  input_value: Value,
+  output_value: Value,
+) -> Bool {
+  let claimed_value =
+    claim_entry.vesting_value |> merge(claim_entry.direct_value) |> negate()
+  let expected_output_value = input_value |> merge(claimed_value)
+  expected_output_value == output_value
+}
+
+pub fn verify_claim(
+  claim_proof: Proof<ClaimEntry>,
+  claim_entry: ClaimEntry,
+  current_root: Root,
+  new_root: Root,
+) -> Bool {
+  let emptied_entry =
+    ClaimEntry { ..claim_entry, direct_value: zero(), vesting_value: zero() }
+  and {
+    is_member(current_root, claim_entry, claim_proof, serialise_entry),
+    is_member(new_root, emptied_entry, claim_proof, serialise_entry),
+  }
+}
+
+pub fn reclaim(datum: TreasuryDatum, tx: Transaction) -> Bool {
+  satisfied(
+    datum.owner,
+    tx.extra_signatories,
+    tx.validity_range,
+    tx.withdrawals,
+  )
+}
+
+pub fn claim(
+  treasury_output_reference: OutputReference,
+  claim_proof: Proof<ClaimEntry>,
+  claim_entry: ClaimEntry,
+  tx: Transaction,
+) -> Bool {
+  expect Some(Input(_, treasury_input)) =
+    find_input(tx.inputs, treasury_output_reference)
+  expect Address(ScriptCredential(treasury_script_hash), _) =
+    treasury_input.address
+  expect [treasury_output] =
+    find_script_outputs(tx.outputs, treasury_script_hash)
+  let current_treasury_datum = extract_treasury_datum(treasury_input.datum)
+  let new_treasury_datum = extract_treasury_datum(treasury_output.datum)
+  and {
+    (treasury_input.address == treasury_output.address)?,
+    verify_value(claim_entry, treasury_input.value, treasury_output.value)?,
+    verify_datum(current_treasury_datum, new_treasury_datum)?,
+    verify_claim(
+      claim_proof,
+      claim_entry,
+      from_hash(current_treasury_datum.claimant_tree),
+      from_hash(new_treasury_datum.claimant_tree),
+    )?,
+    verify_vesting_program(claim_entry, tx)?,
+    satisfied(
+      claim_entry.claimant,
+      tx.extra_signatories,
+      tx.validity_range,
+      tx.withdrawals,
+    )?,
+  }
+}

--- a/vesting_contracts/lib/vesting_contracts/treasury.ak
+++ b/vesting_contracts/lib/vesting_contracts/treasury.ak
@@ -9,11 +9,13 @@ use vesting_contracts/datums.{TreasuryDatum, extract_treasury_datum}
 use vesting_contracts/merkle_tree_blake2b.{Proof, Root, from_hash, is_member}
 use vesting_contracts/redeemers.{ClaimEntry, serialise_entry}
 
-pub fn verify_vesting_program(claim_entry: ClaimEntry, tx: Transaction) -> Bool {
+//Verify that the validator identified by the vesting_hash is present in the withdrawals of this tx
+pub fn verify_vesting_program(vesting_hash: ByteArray, tx: Transaction) -> Bool {
   tx.withdrawals
-    |> has_key(Inline(ScriptCredential(claim_entry.vesting_program)))
+    |> has_key(Inline(ScriptCredential(vesting_hash)))
 }
 
+//Verify that the output datum is identical to the input datum with the merkle tree root replaced
 pub fn verify_datum(
   input_datum: TreasuryDatum,
   output_datum: TreasuryDatum,
@@ -35,6 +37,8 @@ pub fn verify_value(
   expected_output_value == output_value
 }
 
+//Verify that the claim is present in the merkle tree and that the new tree contains the
+//same tree but with the claim emptied
 pub fn verify_claim(
   claim_proof: Proof<ClaimEntry>,
   claim_entry: ClaimEntry,
@@ -49,6 +53,8 @@ pub fn verify_claim(
   }
 }
 
+//Ensure the reclaim tx is signed by the multisigscript owner of the treasury
+//TODO: set and verify a minimum time
 pub fn reclaim(datum: TreasuryDatum, tx: Transaction) -> Bool {
   satisfied(
     datum.owner,
@@ -58,6 +64,7 @@ pub fn reclaim(datum: TreasuryDatum, tx: Transaction) -> Bool {
   )
 }
 
+//User takes their claim from treasury
 pub fn claim(
   treasury_output_reference: OutputReference,
   claim_proof: Proof<ClaimEntry>,
@@ -68,21 +75,30 @@ pub fn claim(
     find_input(tx.inputs, treasury_output_reference)
   expect Address(ScriptCredential(treasury_script_hash), _) =
     treasury_input.address
+  //We expect only 1 treasury in the outputs
   expect [treasury_output] =
     find_script_outputs(tx.outputs, treasury_script_hash)
+  //Cast datums to correct type
   let current_treasury_datum = extract_treasury_datum(treasury_input.datum)
   let new_treasury_datum = extract_treasury_datum(treasury_output.datum)
+
   and {
+    //Treasury address remains the same
     (treasury_input.address == treasury_output.address)?,
+    //Treasury value in output is correct
     verify_value(claim_entry, treasury_input.value, treasury_output.value)?,
+    //Treasury datum in output is correct
     verify_datum(current_treasury_datum, new_treasury_datum)?,
+    //Claim is present in merkle tree and output merkle tree
     verify_claim(
       claim_proof,
       claim_entry,
       from_hash(current_treasury_datum.claimant_tree),
       from_hash(new_treasury_datum.claimant_tree),
     )?,
-    verify_vesting_program(claim_entry, tx)?,
+    //The vesting program defined in the claim is present in withdrawals
+    verify_vesting_program(claim_entry.vesting_program, tx)?,
+    //The transaction is signed by the claimant
     satisfied(
       claim_entry.claimant,
       tx.extra_signatories,

--- a/vesting_contracts/lib/vesting_contracts/util.ak
+++ b/vesting_contracts/lib/vesting_contracts/util.ak
@@ -1,0 +1,22 @@
+use aiken/hash.{Blake2b_224, Hash}
+use aiken/list.{filter}
+use aiken/transaction.{Input}
+use aiken/transaction/credential.{Script, ScriptCredential}
+use aiken/transaction/value.{Value, from_lovelace}
+
+pub fn min_utxo() -> Value {
+  from_lovelace(2_000_000)
+}
+
+//Similar to find_script_outputs, filters Inputs based on script hash
+pub fn find_script_inputs(
+  inputs: List<Input>,
+  script_hash: Hash<Blake2b_224, Script>,
+) -> List<Input> {
+  inputs
+    |> filter(
+        fn(i) {
+          ScriptCredential(script_hash) == i.output.address.payment_credential
+        },
+      )
+}

--- a/vesting_contracts/validators/linear_vesting.ak
+++ b/vesting_contracts/validators/linear_vesting.ak
@@ -9,22 +9,23 @@ use vesting_contracts/linear_vesting/withdrawal.{withdraw}
 
 validator(treasury_hash: Hash<Blake2b_224, Script>) {
   fn linear_spend(
-    datum: LinearVestingDatum,
+    _datum: LinearVestingDatum,
     redeemer: LinearVestingSpendRedeemer,
     ctx: ScriptContext,
   ) -> Bool {
     when ctx.purpose is {
-      Spend(output_reference) -> spend(output_reference, datum, redeemer, ctx)
+      Spend(output_reference) -> spend(output_reference, redeemer, ctx)
       _ -> False
     }
   }
 
+  //Both mint and withdrawfrom is covered by this validator (only 2 functions supported per validator)
   fn linear_mint(
     redeemer: LinearVestingMintRedeemer,
     ctx: ScriptContext,
   ) -> Bool {
     when ctx.purpose is {
-      Mint(_) -> mint(redeemer, ctx)
+      Mint(policy_id) -> mint(policy_id, treasury_hash, redeemer, ctx)
       WithdrawFrom(stake_credential) ->
         withdraw(stake_credential, treasury_hash, redeemer, ctx)
       _ -> False

--- a/vesting_contracts/validators/linear_vesting.ak
+++ b/vesting_contracts/validators/linear_vesting.ak
@@ -1,11 +1,13 @@
+use aiken/hash.{Blake2b_224, Hash}
 use aiken/transaction.{Mint, ScriptContext, Spend, WithdrawFrom}
+use aiken/transaction/credential.{Script}
 use vesting_contracts/linear_vesting/mint.{LinearVestingMintRedeemer, mint}
 use vesting_contracts/linear_vesting/spend.{
   LinearVestingDatum, LinearVestingSpendRedeemer, spend,
 }
 use vesting_contracts/linear_vesting/withdrawal.{withdraw}
 
-validator {
+validator(treasury_hash: Hash<Blake2b_224, Script>) {
   fn linear_spend(
     datum: LinearVestingDatum,
     redeemer: LinearVestingSpendRedeemer,
@@ -23,7 +25,8 @@ validator {
   ) -> Bool {
     when ctx.purpose is {
       Mint(_) -> mint(redeemer, ctx)
-      WithdrawFrom(_) -> withdraw(redeemer, ctx)
+      WithdrawFrom(stake_credential) ->
+        withdraw(stake_credential, treasury_hash, redeemer, ctx)
       _ -> False
     }
   }

--- a/vesting_contracts/validators/treasury.ak
+++ b/vesting_contracts/validators/treasury.ak
@@ -1,16 +1,7 @@
-use aiken/dict.{has_key}
-use aiken/transaction.{
-  InlineDatum, Input, Output, OutputReference, ScriptContext, Spend, Transaction,
-  find_input, find_script_outputs,
-}
-use aiken/transaction/credential.{Address, Inline, ScriptCredential}
-use aiken/transaction/value.{Value, merge, negate, zero}
-use sundae/multisig.{satisfied}
+use aiken/transaction.{ScriptContext, Spend}
 use vesting_contracts/datums.{TreasuryDatum}
-use vesting_contracts/merkle_tree_blake2b.{Proof, Root, from_hash, is_member}
-use vesting_contracts/redeemers.{
-  Claim, ClaimEntry, Reclaim, TreasuryRedeemer, serialise_entry,
-}
+use vesting_contracts/redeemers.{Claim, Reclaim, TreasuryRedeemer}
+use vesting_contracts/treasury.{claim, reclaim}
 
 validator {
   fn treasury(
@@ -28,86 +19,4 @@ validator {
       _ -> False
     }
   }
-}
-
-fn claim(
-  treasury_output_reference: OutputReference,
-  claim_proof: Proof<ClaimEntry>,
-  claim_entry: ClaimEntry,
-  tx: Transaction,
-) -> Bool {
-  expect Some(Input(_, treasury_input)) =
-    find_input(tx.inputs, treasury_output_reference)
-  expect Address(ScriptCredential(treasury_script_hash), _) =
-    treasury_input.address
-  expect InlineDatum(treasury_input_data) = treasury_input.datum
-  expect [treasury_output] =
-    find_script_outputs(tx.outputs, treasury_script_hash)
-  expect InlineDatum(treasury_output_data) = treasury_output.datum
-  expect current_treasury_datum: TreasuryDatum = treasury_input_data
-  expect new_treasury_datum: TreasuryDatum = treasury_output_data
-  and {
-    (treasury_input.address == treasury_output.address)?,
-    verify_value(claim_entry, treasury_input.value, treasury_output.value)?,
-    verify_datum(current_treasury_datum, new_treasury_datum)?,
-    verify_claim(
-      claim_proof,
-      claim_entry,
-      from_hash(current_treasury_datum.claimant_tree),
-      from_hash(new_treasury_datum.claimant_tree),
-    )?,
-    verify_vesting_program(current_treasury_datum, tx)?,
-    satisfied(
-      claim_entry.claimant,
-      tx.extra_signatories,
-      tx.validity_range,
-      tx.withdrawals,
-    )?,
-  }
-}
-
-fn verify_vesting_program(datum: TreasuryDatum, tx: Transaction) -> Bool {
-  tx.withdrawals
-    |> has_key(Inline(ScriptCredential(datum.vesting_program)))
-}
-
-fn verify_datum(input_datum: TreasuryDatum, output_datum: TreasuryDatum) -> Bool {
-  output_datum == TreasuryDatum {
-    ..input_datum,
-    claimant_tree: output_datum.claimant_tree,
-  }
-}
-
-fn verify_value(
-  claim_entry: ClaimEntry,
-  input_value: Value,
-  output_value: Value,
-) -> Bool {
-  let claimed_value =
-    claim_entry.vesting_value |> merge(claim_entry.direct_value) |> negate()
-  let expected_output_value = input_value |> merge(claimed_value)
-  expected_output_value == output_value
-}
-
-fn verify_claim(
-  claim_proof: Proof<ClaimEntry>,
-  claim_entry: ClaimEntry,
-  current_root: Root,
-  new_root: Root,
-) -> Bool {
-  let emptied_entry =
-    ClaimEntry { ..claim_entry, direct_value: zero(), vesting_value: zero() }
-  and {
-    is_member(current_root, claim_entry, claim_proof, serialise_entry),
-    is_member(new_root, emptied_entry, claim_proof, serialise_entry),
-  }
-}
-
-fn reclaim(datum: TreasuryDatum, tx: Transaction) -> Bool {
-  satisfied(
-    datum.owner,
-    tx.extra_signatories,
-    tx.validity_range,
-    tx.withdrawals,
-  )
 }

--- a/vesting_contracts/validators/treasury.ak
+++ b/vesting_contracts/validators/treasury.ak
@@ -11,7 +11,10 @@ validator {
   ) -> Bool {
     when ctx.purpose is {
       Spend(output_reference) ->
-        when redeemer.tx_type is {
+        //Two tx types:
+        //Claim: a user claims their value according to their claim as stored in the merkle tree
+        //Reclaim: Treasury creator reclaims any remaining tokens
+        when redeemer is {
           Claim(claim_proof, claim_entry) ->
             claim(output_reference, claim_proof, claim_entry, ctx.transaction)
           Reclaim -> reclaim(datum, ctx.transaction)


### PR DESCRIPTION
We set the logic such that it allows for multiple vesting inputs and outputs as long as they follow the same vesting schedule. This gives the user freedom to combine and split vesting nft's as they please.